### PR TITLE
check if locale is set in localStorage

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -123,11 +123,17 @@
                     suffix = match[4];
                     locale = masterConfig.locale;
                     if (!locale) {
-                        locale = masterConfig.locale =
-                            typeof navigator === 'undefined' ? 'root' :
-                            ((navigator.languages && navigator.languages[0]) ||
-                             navigator.language ||
-                             navigator.userLanguage || 'root').toLowerCase();
+                        // Check if locale is set in localStorage otherwise use browser language
+                        if (typeof localStorage !== "undefined" && localStorage.getItem('locale')) {
+                            locale = masterConfig.locale = localStorage.getItem('locale');
+                        }
+                        else {
+                            locale = masterConfig.locale =
+                                typeof navigator === "undefined" ? "root" :
+                                    ((navigator.languages && navigator.languages[0]) ||
+                                     navigator.language ||
+                                     navigator.userLanguage || "root").toLowerCase();
+                        }
                     }
                     parts = locale.split('-');
                 }


### PR DESCRIPTION
We want to be able to switch the language by a locale value in the localStorage instead of a fixed value inside the config file or the browser language.

Preference is:
masterConfig > localStorage > browser language

From what I've tested so far the previous behavior isn't impacted by this.
